### PR TITLE
Refactor Rand class

### DIFF
--- a/KeyEngine/Mathematics/Rand.cs
+++ b/KeyEngine/Mathematics/Rand.cs
@@ -1,31 +1,20 @@
-﻿namespace KeyEngine.Mathematics
+﻿using NAudio.Codecs;
+using System.Numerics;
+
+namespace KeyEngine.Mathematics
 {
     public static class Rand
     {
         private static Random rand = new Random();
+        
+        public static int Range(int min, int max) => rand.Next(min, max);
+        public static double Range(double min, double max) => Lerp(min, max, rand.NextSingle());
+        public static float Range(float min, float max) => Lerp(min, max, rand.NextSingle());
 
-        public static double GenValue(double min, double max)
+        private static T Lerp<T>(T min, T max, T range01) where T : INumber<T>
         {
-            if (min > max || max < min)
-                throw new ArgumentOutOfRangeException();
-
-            return rand.NextDouble() * (max - min) + min;
-        }
-
-        public static float GenValue(float min, float max)
-        {
-            if (min > max || max < min)
-                throw new ArgumentOutOfRangeException();
-
-            return rand.NextSingle() * (max - min) + min;
-        }
-
-        public static int GenValue(int min, int max)
-        {
-            if (min > max || max < min)
-                throw new ArgumentOutOfRangeException();
-
-            return rand.Next(min, max);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(min, max, nameof(min));
+            return min + (max - min) * range01;
         }
     }
 }

--- a/KeyEngine/Mathematics/Rand.cs
+++ b/KeyEngine/Mathematics/Rand.cs
@@ -1,15 +1,16 @@
-﻿using NAudio.Codecs;
-using System.Numerics;
+﻿using System.Numerics;
 
 namespace KeyEngine.Mathematics
 {
     public static class Rand
     {
-        private static Random rand = new Random();
-        
-        public static int Range(int min, int max) => rand.Next(min, max);
-        public static double Range(double min, double max) => Lerp(min, max, rand.NextSingle());
-        public static float Range(float min, float max) => Lerp(min, max, rand.NextSingle());
+        private static Random Rng { get; set; } = new Random();
+
+        public static void SetSeed(int seed) => Rng = new(seed);
+
+        public static int Range(int min, int max) => Rng.Next(min, max);
+        public static double Range(double min, double max) => Lerp(min, max, Rng.NextSingle());
+        public static float Range(float min, float max) => Lerp(min, max, Rng.NextSingle());
 
         private static T Lerp<T>(T min, T max, T range01) where T : INumber<T>
         {

--- a/KeyEngine/Mathematics/Rand.cs
+++ b/KeyEngine/Mathematics/Rand.cs
@@ -9,7 +9,7 @@ namespace KeyEngine.Mathematics
         public static void SetSeed(int seed) => Rng = new(seed);
 
         public static int Range(int min, int max) => Rng.Next(min, max);
-        public static double Range(double min, double max) => Lerp(min, max, Rng.NextSingle());
+        public static double Range(double min, double max) => Lerp(min, max, Rng.NextDouble());
         public static float Range(float min, float max) => Lerp(min, max, Rng.NextSingle());
 
         private static T Lerp<T>(T min, T max, T range01) where T : INumber<T>


### PR DESCRIPTION
- Renamed GetValue to Range
- Added SetSeed method
- Removed code duplication (`... * (max - min) + min` and `min > max || max < min`)

In general, Rand class became more consistent, easy to read, and has no duplicated checks:
- `min > max` and `max < min` are literally the same
- for `rand.Next(int, int)` - `min < max` is already implemented
 
`SetSeed(int seed)` is supposed to make the RNG predictable. 